### PR TITLE
Video queue

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -283,6 +283,14 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -905,6 +913,29 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "forwarded": {
       "version": "0.1.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "@types/uniqid": "^4.1.3",
     "@typescript-eslint/eslint-plugin": "^2.12.0",
     "@typescript-eslint/parser": "^2.12.0",
+    "axios": "^0.19.2",
     "body-parser": "^1.19.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",

--- a/backend/src/core/api.ts
+++ b/backend/src/core/api.ts
@@ -52,7 +52,7 @@ export default class API {
       while (ids.includes(roomId)) {
         roomId = uniqid();
       }
-      await this.db.createRoom(roomId, req.body);
+      await this.db.setRoom(roomId, req.body);
       res.send(roomId);
     } catch (err) {
       res.status(500).send("Error: Couldn't create room.");

--- a/backend/src/core/database.ts
+++ b/backend/src/core/database.ts
@@ -1,10 +1,6 @@
 import redis from "redis";
 import logger from "../config/logger";
-
-interface Room {
-  name: string;
-  url: string;
-}
+import Room from "../models/room";
 
 export default class Database {
   private client: redis.RedisClient;
@@ -19,12 +15,12 @@ export default class Database {
     this.initListeners();
   }
 
-  public async createRoom(id: string, room: Room): Promise<void> {
+  public async setRoom(id: string, room: Room): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      logger.info(`Create room ${id}`);
+      logger.info(`Set room ${id}`);
       this.client.set(`room:${id}`, JSON.stringify(room), (err, res) => {
         if (err) {
-          logger.error(`Couldn't create room: ${err}`);
+          logger.error(`Couldn't set room: ${err}`);
           reject(err);
         }
         resolve();

--- a/backend/src/core/server.ts
+++ b/backend/src/core/server.ts
@@ -7,16 +7,19 @@ import API from "./api";
 import { Event } from "../sockets/event";
 import joinRoom from "../sockets/handler";
 import logger from "../config/logger";
+import RoomSocketHandler from "../sockets/handler";
 
 export default class Server {
   private app: express.Application;
   private port: number;
   private httpServer: http.Server;
+  private database: Database;
 
   constructor(port?: number) {
     this.port = port || 8080;
     this.app = express();
     this.httpServer = http.createServer(this.app);
+    this.database = new Database(6379, process.env.DB_HOST);
     this.app.use((req, res, next) => {
       res.header("Access-Control-Allow-Origin", "http://localhost:3000");
       res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
@@ -24,7 +27,7 @@ export default class Server {
     });
     this.app.use(bodyParser.json());
     this.app.use(bodyParser.urlencoded({ extended: true }));
-    this.app.use("/", new API(new Database(6379, process.env.DB_HOST)).router);
+    this.app.use("/", new API(this.database).router);
     this.setupSockets();
   }
 
@@ -40,7 +43,7 @@ export default class Server {
       logger.debug(`Socket ${socket.id} connected.`);
 
       socket.on(Event.JOIN_ROOM, roomId => {
-        joinRoom(io, socket, roomId);
+        new RoomSocketHandler(this.database, io, socket, roomId).initialize();
       });
 
       socket.on(Event.DISCONNECT, socket => {

--- a/backend/src/models/room.ts
+++ b/backend/src/models/room.ts
@@ -1,0 +1,7 @@
+import Video from "./video";
+
+export default interface Room {
+  name: string;
+  url: string;
+  videoQueue: Video[];
+}

--- a/backend/src/models/room.ts
+++ b/backend/src/models/room.ts
@@ -2,6 +2,6 @@ import Video from "./video";
 
 export default interface Room {
   name: string;
-  url: string;
+  currVideoId: string;
   videoQueue: Video[];
 }

--- a/backend/src/models/video.ts
+++ b/backend/src/models/video.ts
@@ -1,4 +1,5 @@
 export default interface Video {
+  id: string;
   title: string;
   url: string;
 }

--- a/backend/src/models/video.ts
+++ b/backend/src/models/video.ts
@@ -1,5 +1,5 @@
 export default interface Video {
   id: string;
   title: string;
-  url: string;
+  currVideoId: string;
 }

--- a/backend/src/models/video.ts
+++ b/backend/src/models/video.ts
@@ -1,0 +1,4 @@
+export default interface Video {
+  title: string;
+  url: string;
+}

--- a/backend/src/sockets/event.ts
+++ b/backend/src/sockets/event.ts
@@ -1,9 +1,10 @@
 export enum Event {
+  ADD_TO_QUEUE = "add to queue",
   CONNECT = "connect",
   DISCONNECT = "disconnect",
   MESSAGE = "message",
   JOIN_ROOM = "join room",
   PLAY_VIDEO = "play video",
   PAUSE_VIDEO = "pause video",
-  ADD_TO_QUEUE = "add to queue"
+  REQUEST_ADD_TO_QUEUE = "request add to queue"
 }

--- a/backend/src/sockets/event.ts
+++ b/backend/src/sockets/event.ts
@@ -7,5 +7,6 @@ export enum Event {
   PLAY_VIDEO = "play video",
   PAUSE_VIDEO = "pause video",
   REQUEST_ADD_TO_QUEUE = "request add to queue",
-  SET_VIDEO = "set video"
+  SET_VIDEO = "set video",
+  UPDATE_ROOM = "update room"
 }

--- a/backend/src/sockets/event.ts
+++ b/backend/src/sockets/event.ts
@@ -6,5 +6,6 @@ export enum Event {
   JOIN_ROOM = "join room",
   PLAY_VIDEO = "play video",
   PAUSE_VIDEO = "pause video",
-  REQUEST_ADD_TO_QUEUE = "request add to queue"
+  REQUEST_ADD_TO_QUEUE = "request add to queue",
+  SET_VIDEO = "set video"
 }

--- a/backend/src/sockets/event.ts
+++ b/backend/src/sockets/event.ts
@@ -4,5 +4,6 @@ export enum Event {
   MESSAGE = "message",
   JOIN_ROOM = "join room",
   PLAY_VIDEO = "play video",
-  PAUSE_VIDEO = "pause video"
+  PAUSE_VIDEO = "pause video",
+  ADD_TO_QUEUE = "add to queue"
 }

--- a/backend/src/sockets/handler.ts
+++ b/backend/src/sockets/handler.ts
@@ -3,6 +3,7 @@ import { Event } from "./event";
 import axios from "axios";
 import logger from "../config/logger";
 import qs from "querystring";
+import Video from "../models/video";
 
 type EventHandler = {
   [event in Event]?: (io: Server, socket: Socket, roomId: string, args: any) => Promise<void>;
@@ -50,10 +51,17 @@ handlers[Event.REQUEST_ADD_TO_QUEUE] = async (
     const playerResponse = JSON.parse(videoInfo["player_response"] as string);
     const videoTitle = playerResponse.videoDetails.title;
     logger.info(`Video found: ${videoTitle}`);
-    io.in(roomId).emit(Event.ADD_TO_QUEUE, videoTitle);
+
+    const video: Video = { title: videoTitle, url: videoUrl };
+    io.in(roomId).emit(Event.ADD_TO_QUEUE, video);
   } catch {
     logger.error("Failed to find info about video");
   }
+};
+
+handlers[Event.SET_VIDEO] = (io: Server, socket: Socket, roomId: string, video: Video): Promise<void> => {
+  io.in(roomId).emit(Event.SET_VIDEO, video);
+  return Promise.resolve();
 };
 
 export default joinRoom;

--- a/backend/src/sockets/handler.ts
+++ b/backend/src/sockets/handler.ts
@@ -65,13 +65,22 @@ class RoomSocketHandler {
           logger.info(`Video found: ${videoTitle}`);
 
           const video: Video = { id: uniqid(), title: videoTitle, url: videoUrl };
+
+          const room = await this.database.getRoom(this.roomId);
+          room.videoQueue.push(video);
+          await this.database.setRoom(this.roomId, room);
+
           this.io.in(this.roomId).emit(Event.ADD_TO_QUEUE, video);
         } catch {
           logger.error("Failed to find info about video");
         }
       },
 
-      [Event.SET_VIDEO]: (video: Video): Promise<void> => {
+      [Event.SET_VIDEO]: async (video: Video): Promise<void> => {
+        const room = await this.database.getRoom(this.roomId);
+        room.url = video.url;
+        await this.database.setRoom(this.roomId, room);
+
         this.io.in(this.roomId).emit(Event.SET_VIDEO, video);
         return Promise.resolve();
       }

--- a/backend/src/sockets/handler.ts
+++ b/backend/src/sockets/handler.ts
@@ -28,4 +28,8 @@ handlers[Event.PAUSE_VIDEO] = (io: Server, socket: Socket, roomId: string, time:
   socket.to(roomId).emit(Event.PAUSE_VIDEO, time);
 };
 
+handlers[Event.ADD_TO_QUEUE] = (io: Server, socket: Socket, roomId: string, videoUrl: string): void => {
+  socket.to(roomId).emit(Event.ADD_TO_QUEUE, videoUrl);
+};
+
 export default joinRoom;

--- a/backend/src/sockets/handler.ts
+++ b/backend/src/sockets/handler.ts
@@ -1,8 +1,11 @@
 import { Server, Socket } from "socket.io";
 import { Event } from "./event";
+import axios from "axios";
+import logger from "../config/logger";
+import qs from "querystring";
 
 type EventHandler = {
-  [event in Event]?: Function;
+  [event in Event]?: (io: Server, socket: Socket, roomId: string, args: any) => Promise<void>;
 };
 
 const handlers: EventHandler = {};
@@ -12,24 +15,45 @@ const joinRoom = (io: Server, socket: Socket, roomId: string): void => {
     socket.to(roomId).emit(Event.MESSAGE, "A new user has joined the room!");
     for (const [event, handler] of Object.entries(handlers)) {
       if (handler) {
-        socket.on(event, data => {
-          handler(io, socket, roomId, data);
+        socket.on(event, async data => {
+          await handler(io, socket, roomId, data);
         });
       }
     }
   });
 };
 
-handlers[Event.PLAY_VIDEO] = (io: Server, socket: Socket, roomId: string, time: number): void => {
+handlers[Event.PLAY_VIDEO] = (io: Server, socket: Socket, roomId: string, time: number): Promise<void> => {
   socket.to(roomId).emit(Event.PLAY_VIDEO, time);
+  return Promise.resolve();
 };
 
-handlers[Event.PAUSE_VIDEO] = (io: Server, socket: Socket, roomId: string, time: number): void => {
+handlers[Event.PAUSE_VIDEO] = (io: Server, socket: Socket, roomId: string, time: number): Promise<void> => {
   socket.to(roomId).emit(Event.PAUSE_VIDEO, time);
+  return Promise.resolve();
 };
 
-handlers[Event.ADD_TO_QUEUE] = (io: Server, socket: Socket, roomId: string, videoUrl: string): void => {
-  socket.to(roomId).emit(Event.ADD_TO_QUEUE, videoUrl);
+handlers[Event.REQUEST_ADD_TO_QUEUE] = async (
+  io: Server,
+  socket: Socket,
+  roomId: string,
+  videoUrl: string
+): Promise<void> => {
+  logger.info("REQUEST_ADD_TO_QUEUE called!");
+
+  try {
+    // TODO: Improve method of finding video ID to account for extra query parameters
+    const videoId = videoUrl.split("v=")[1];
+
+    const videoInfoResponse = await axios.get(`https://youtube.com/get_video_info?video_id=${videoId}`);
+    const videoInfo = qs.parse(videoInfoResponse.data);
+    const playerResponse = JSON.parse(videoInfo["player_response"] as string);
+    const videoTitle = playerResponse.videoDetails.title;
+    logger.info(`Video found: ${videoTitle}`);
+    io.in(roomId).emit(Event.ADD_TO_QUEUE, videoTitle);
+  } catch {
+    logger.error("Failed to find info about video");
+  }
 };
 
 export default joinRoom;

--- a/backend/src/sockets/handler.ts
+++ b/backend/src/sockets/handler.ts
@@ -5,64 +5,78 @@ import logger from "../config/logger";
 import qs from "querystring";
 import Video from "../models/video";
 import uniqid from "uniqid";
+import Database from "../core/database";
 
 type EventHandler = {
-  [event in Event]?: (io: Server, socket: Socket, roomId: string, args: any) => Promise<void>;
+  [event in Event]?: (args: any) => Promise<void>;
 };
 
-const handlers: EventHandler = {};
+class RoomSocketHandler {
+  private database: Database;
+  private io: Server;
+  private socket: Socket;
+  private roomId: string;
 
-const joinRoom = (io: Server, socket: Socket, roomId: string): void => {
-  socket.join(roomId, () => {
-    socket.to(roomId).emit(Event.MESSAGE, "A new user has joined the room!");
-    for (const [event, handler] of Object.entries(handlers)) {
-      if (handler) {
-        socket.on(event, async data => {
-          await handler(io, socket, roomId, data);
-        });
-      }
-    }
-  });
-};
-
-handlers[Event.PLAY_VIDEO] = (io: Server, socket: Socket, roomId: string, time: number): Promise<void> => {
-  socket.to(roomId).emit(Event.PLAY_VIDEO, time);
-  return Promise.resolve();
-};
-
-handlers[Event.PAUSE_VIDEO] = (io: Server, socket: Socket, roomId: string, time: number): Promise<void> => {
-  socket.to(roomId).emit(Event.PAUSE_VIDEO, time);
-  return Promise.resolve();
-};
-
-handlers[Event.REQUEST_ADD_TO_QUEUE] = async (
-  io: Server,
-  socket: Socket,
-  roomId: string,
-  videoUrl: string
-): Promise<void> => {
-  logger.info("REQUEST_ADD_TO_QUEUE called!");
-
-  try {
-    // TODO: Improve method of finding video ID to account for extra query parameters
-    const videoId = videoUrl.split("v=")[1];
-
-    const videoInfoResponse = await axios.get(`https://youtube.com/get_video_info?video_id=${videoId}`);
-    const videoInfo = qs.parse(videoInfoResponse.data);
-    const playerResponse = JSON.parse(videoInfo["player_response"] as string);
-    const videoTitle = playerResponse.videoDetails.title;
-    logger.info(`Video found: ${videoTitle}`);
-
-    const video: Video = { id: uniqid(), title: videoTitle, url: videoUrl };
-    io.in(roomId).emit(Event.ADD_TO_QUEUE, video);
-  } catch {
-    logger.error("Failed to find info about video");
+  constructor(database: Database, io: Server, socket: Socket, roomId: string) {
+    this.database = database;
+    this.io = io;
+    this.socket = socket;
+    this.roomId = roomId;
   }
-};
 
-handlers[Event.SET_VIDEO] = (io: Server, socket: Socket, roomId: string, video: Video): Promise<void> => {
-  io.in(roomId).emit(Event.SET_VIDEO, video);
-  return Promise.resolve();
-};
+  initialize(): void {
+    this.socket.join(this.roomId, () => {
+      const handlers = this.createEventHandler();
 
-export default joinRoom;
+      this.socket.to(this.roomId).emit(Event.MESSAGE, "A new user has joined the room!");
+      for (const [event, handler] of Object.entries(handlers)) {
+        if (handler) {
+          this.socket.on(event, async data => {
+            await handler(data);
+          });
+        }
+      }
+    });
+  }
+
+  private createEventHandler(): EventHandler {
+    return {
+      [Event.PLAY_VIDEO]: (time: number): Promise<void> => {
+        this.socket.to(this.roomId).emit(Event.PLAY_VIDEO, time);
+        return Promise.resolve();
+      },
+
+      [Event.PAUSE_VIDEO]: (time: number): Promise<void> => {
+        this.socket.to(this.roomId).emit(Event.PAUSE_VIDEO, time);
+        return Promise.resolve();
+      },
+
+      [Event.REQUEST_ADD_TO_QUEUE]: async (videoUrl: string): Promise<void> => {
+        logger.info("REQUEST_ADD_TO_QUEUE called!");
+
+        try {
+          // TODO: Improve method of finding video ID to account for extra query parameters
+          const videoId = videoUrl.split("v=")[1];
+
+          const videoInfoResponse = await axios.get(`https://youtube.com/get_video_info?video_id=${videoId}`);
+          const videoInfo = qs.parse(videoInfoResponse.data);
+          const playerResponse = JSON.parse(videoInfo["player_response"] as string);
+          const videoTitle = playerResponse.videoDetails.title;
+          logger.info(`Video found: ${videoTitle}`);
+
+          const video: Video = { id: uniqid(), title: videoTitle, url: videoUrl };
+          this.io.in(this.roomId).emit(Event.ADD_TO_QUEUE, video);
+        } catch {
+          logger.error("Failed to find info about video");
+        }
+      },
+
+      [Event.SET_VIDEO]: (video: Video): Promise<void> => {
+        this.io.in(this.roomId).emit(Event.SET_VIDEO, video);
+        return Promise.resolve();
+      }
+    };
+  }
+}
+
+export default RoomSocketHandler;

--- a/backend/src/sockets/handler.ts
+++ b/backend/src/sockets/handler.ts
@@ -59,12 +59,11 @@ class RoomSocketHandler {
     return Promise.resolve();
   }
 
-  private async requestAddToQueue(videoUrl: string): Promise<void> {
+  private async requestAddToQueue(videoId: string): Promise<void> {
     logger.info("REQUEST_ADD_TO_QUEUE called!");
 
     try {
       // TODO: Improve method of finding video ID to account for extra query parameters
-      const videoId = videoUrl.split("v=")[1];
 
       const videoInfoResponse = await axios.get(`https://youtube.com/get_video_info?video_id=${videoId}`);
       const videoInfo = qs.parse(videoInfoResponse.data);
@@ -72,7 +71,7 @@ class RoomSocketHandler {
       const videoTitle = playerResponse.videoDetails.title;
       logger.info(`Video found: ${videoTitle}`);
 
-      const video: Video = { id: uniqid(), title: videoTitle, url: videoUrl };
+      const video: Video = { id: uniqid(), title: videoTitle, currVideoId: videoId };
 
       const room = await this.database.getRoom(this.roomId);
       room.videoQueue.push(video);
@@ -86,7 +85,7 @@ class RoomSocketHandler {
 
   private async setVideo(video: Video): Promise<void> {
     const room = await this.database.getRoom(this.roomId);
-    room.url = video.url;
+    room.currVideoId = video.currVideoId;
 
     const videoQueue: Video[] = [];
     let foundVideo = false;

--- a/backend/src/sockets/handler.ts
+++ b/backend/src/sockets/handler.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 import logger from "../config/logger";
 import qs from "querystring";
 import Video from "../models/video";
+import uniqid from "uniqid";
 
 type EventHandler = {
   [event in Event]?: (io: Server, socket: Socket, roomId: string, args: any) => Promise<void>;
@@ -52,7 +53,7 @@ handlers[Event.REQUEST_ADD_TO_QUEUE] = async (
     const videoTitle = playerResponse.videoDetails.title;
     logger.info(`Video found: ${videoTitle}`);
 
-    const video: Video = { title: videoTitle, url: videoUrl };
+    const video: Video = { id: uniqid(), title: videoTitle, url: videoUrl };
     io.in(roomId).emit(Event.ADD_TO_QUEUE, video);
   } catch {
     logger.error("Failed to find info about video");

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1310,6 +1310,14 @@
         }
       }
     },
+    "@material-ui/icons": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.5.1.tgz",
+      "integrity": "sha512-YZ/BgJbXX4a0gOuKWb30mBaHaoXRqPanlePam83JQPZ/y4kl+3aW0Wv9tlR70hB5EGAkEJGW5m4ktJwMgxQAeA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.5.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.5.1",
+    "@material-ui/icons": "^4.5.1",
     "@types/jest": "24.0.19",
     "@types/node": "12.7.12",
     "@types/react": "16.9.6",

--- a/frontend/src/components/Create.tsx
+++ b/frontend/src/components/Create.tsx
@@ -41,7 +41,7 @@ class Create extends React.Component<Props, State> {
 
   async handleCreateRoom() {
     const res = await axios.post("http://localhost:8080/rooms", {
-      url: this.state.url,
+      currVideoId: this.state.url.replace("https://www.youtube.com/watch?v=", ""),
       name: this.state.name,
       videoQueue: []
     });

--- a/frontend/src/components/Create.tsx
+++ b/frontend/src/components/Create.tsx
@@ -42,7 +42,8 @@ class Create extends React.Component<Props, State> {
   async handleCreateRoom() {
     const res = await axios.post("http://localhost:8080/rooms", {
       url: this.state.url,
-      name: this.state.name
+      name: this.state.name,
+      videoQueue: []
     });
     this.setState({ id: res.data, redirect: true });
   }

--- a/frontend/src/components/Queue.tsx
+++ b/frontend/src/components/Queue.tsx
@@ -1,45 +1,25 @@
 import React from "react";
 import { List, ListItem, ListItemText, TextField, ListItemSecondaryAction, IconButton } from "@material-ui/core";
 import { createStyles, withStyles } from "@material-ui/core/styles";
-import { Event } from "../sockets/event";
 import AddIcon from "@material-ui/icons/Add";
 import Video from "../models/video";
 
 interface Props {
   classes: any;
-  socket: SocketIOClient.Socket;
+  onAddVideo: (url: string) => void;
+  videos: Video[];
 }
 
 interface State {
   newVideoUrl: string;
-  videos: Video[];
 }
 
 class Queue extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      newVideoUrl: "",
-      videos: []
+      newVideoUrl: ""
     };
-
-    this.add = this.add.bind(this);
-    this.requestAdd = this.requestAdd.bind(this);
-  }
-
-  requestAdd(videoUrl: string): void {
-    this.props.socket.emit(Event.REQUEST_ADD_TO_QUEUE, videoUrl);
-  }
-
-  add(video: Video): void {
-    const videos = this.state.videos;
-    videos.push(video);
-
-    this.setState({ videos });
-  }
-
-  componentDidMount() {
-    this.props.socket.on(Event.ADD_TO_QUEUE, (video: Video) => this.add(video));
   }
 
   render() {
@@ -56,12 +36,12 @@ class Queue extends React.Component<Props, State> {
             onChange={event => this.setState({ newVideoUrl: event.target.value })}
           />
           <ListItemSecondaryAction>
-            <IconButton edge="end" aria-label="comments" onClick={() => this.requestAdd(this.state.newVideoUrl)}>
+            <IconButton edge="end" aria-label="comments" onClick={() => this.props.onAddVideo(this.state.newVideoUrl)}>
               <AddIcon style={{ color: "white" }} />
             </IconButton>
           </ListItemSecondaryAction>
         </ListItem>
-        {this.state.videos.map((video, i) => (
+        {this.props.videos.map((video, i) => (
           <ListItem key={i}>
             <ListItemText primary={video.title} />
           </ListItem>

--- a/frontend/src/components/Queue.tsx
+++ b/frontend/src/components/Queue.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { List, ListItem, ListItemText, ListSubheader } from "@material-ui/core";
+import { createStyles, withStyles } from "@material-ui/core/styles";
+import { Event } from "../sockets/event";
+
+interface Video {
+  name: string;
+  url: string;
+}
+
+interface Props {
+  classes: any;
+  socket: SocketIOClient.Socket;
+}
+
+interface State {
+  videos: Video[];
+}
+
+class Queue extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      videos: []
+    };
+
+    this.addVideo = this.addVideo.bind(this);
+    this.handleAddVideo = this.handleAddVideo.bind(this);
+  }
+
+  handleAddVideo(): void {
+    debugger;
+    this.addVideo();
+    this.props.socket.emit(Event.ADD_TO_QUEUE);
+  }
+
+  addVideo(): void {
+    debugger;
+    const videos = this.state.videos;
+    const newVideo = { name: "Test Video", url: "https://youtube.com" };
+    videos.push(newVideo);
+
+    this.setState({ videos });
+  }
+
+  componentDidMount() {
+    debugger;
+    this.props.socket.on(Event.ADD_TO_QUEUE, this.addVideo);
+  }
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <List component="nav" className={classes.list}>
+        {this.state.videos.map(video => (
+          <ListItem>
+            <ListItemText primary={video.name} />
+          </ListItem>
+        ))}
+        <ListItem button onClick={this.handleAddVideo}>
+          <ListItemText primary="Add video" />
+        </ListItem>
+      </List>
+    );
+  }
+}
+
+const materialUiStyles = createStyles({
+  list: {
+    color: "white"
+  }
+});
+
+export default withStyles(materialUiStyles)(Queue);

--- a/frontend/src/components/Queue.tsx
+++ b/frontend/src/components/Queue.tsx
@@ -6,7 +6,7 @@ import Video from "../models/video";
 
 interface Props {
   classes: any;
-  onAddVideo: (url: string) => void;
+  onAddVideo: (videoId: string) => void;
   videos: Video[];
 }
 
@@ -36,7 +36,13 @@ class Queue extends React.Component<Props, State> {
             onChange={event => this.setState({ newVideoUrl: event.target.value })}
           />
           <ListItemSecondaryAction>
-            <IconButton edge="end" aria-label="comments" onClick={() => this.props.onAddVideo(this.state.newVideoUrl)}>
+            <IconButton
+              edge="end"
+              aria-label="comments"
+              onClick={() =>
+                this.props.onAddVideo(this.state.newVideoUrl.replace("https://www.youtube.com/watch?v=", ""))
+              }
+            >
               <AddIcon style={{ color: "white" }} />
             </IconButton>
           </ListItemSecondaryAction>

--- a/frontend/src/components/Queue.tsx
+++ b/frontend/src/components/Queue.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { List, ListItem, ListItemText, ListSubheader } from "@material-ui/core";
+import { List, ListItem, ListItemText, TextField, ListItemSecondaryAction, IconButton } from "@material-ui/core";
 import { createStyles, withStyles } from "@material-ui/core/styles";
 import { Event } from "../sockets/event";
+import AddIcon from "@material-ui/icons/Add";
 
 interface Video {
   name: string;
@@ -14,6 +15,7 @@ interface Props {
 }
 
 interface State {
+  newVideoUrl: string;
   videos: Video[];
 }
 
@@ -21,23 +23,24 @@ class Queue extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
+      newVideoUrl: "",
       videos: []
     };
 
-    this.addVideo = this.addVideo.bind(this);
-    this.handleAddVideo = this.handleAddVideo.bind(this);
+    this.add = this.add.bind(this);
+    this.requestAdd = this.requestAdd.bind(this);
   }
 
-  handleAddVideo(): void {
+  requestAdd(videoUrl: string): void {
     debugger;
-    this.addVideo();
-    this.props.socket.emit(Event.ADD_TO_QUEUE);
+    this.props.socket.emit(Event.REQUEST_ADD_TO_QUEUE, videoUrl);
   }
 
-  addVideo(): void {
+  add(title: string): void {
     debugger;
+    console.log("Adding a video");
     const videos = this.state.videos;
-    const newVideo = { name: "Test Video", url: "https://youtube.com" };
+    const newVideo = { name: title, url: "https://youtube.com" };
     videos.push(newVideo);
 
     this.setState({ videos });
@@ -45,7 +48,7 @@ class Queue extends React.Component<Props, State> {
 
   componentDidMount() {
     debugger;
-    this.props.socket.on(Event.ADD_TO_QUEUE, this.addVideo);
+    this.props.socket.on(Event.ADD_TO_QUEUE, (title: string) => this.add(title));
   }
 
   render() {
@@ -53,14 +56,25 @@ class Queue extends React.Component<Props, State> {
 
     return (
       <List component="nav" className={classes.list}>
-        {this.state.videos.map(video => (
-          <ListItem>
+        <ListItem>
+          <TextField
+            InputProps={{ className: classes.textField }}
+            InputLabelProps={{ className: classes.textField }}
+            label="YouTube URL"
+            variant="outlined"
+            onChange={event => this.setState({ newVideoUrl: event.target.value })}
+          />
+          <ListItemSecondaryAction>
+            <IconButton edge="end" aria-label="comments" onClick={() => this.requestAdd(this.state.newVideoUrl)}>
+              <AddIcon style={{ color: "white" }} />
+            </IconButton>
+          </ListItemSecondaryAction>
+        </ListItem>
+        {this.state.videos.map((video, i) => (
+          <ListItem key={i}>
             <ListItemText primary={video.name} />
           </ListItem>
         ))}
-        <ListItem button onClick={this.handleAddVideo}>
-          <ListItemText primary="Add video" />
-        </ListItem>
       </List>
     );
   }
@@ -68,6 +82,13 @@ class Queue extends React.Component<Props, State> {
 
 const materialUiStyles = createStyles({
   list: {
+    color: "white"
+  },
+  textField: {
+    "& input + fieldset": {
+      borderColor: "green !important",
+      borderWidth: 2
+    },
     color: "white"
   }
 });

--- a/frontend/src/components/Queue.tsx
+++ b/frontend/src/components/Queue.tsx
@@ -3,11 +3,7 @@ import { List, ListItem, ListItemText, TextField, ListItemSecondaryAction, IconB
 import { createStyles, withStyles } from "@material-ui/core/styles";
 import { Event } from "../sockets/event";
 import AddIcon from "@material-ui/icons/Add";
-
-interface Video {
-  name: string;
-  url: string;
-}
+import Video from "../models/video";
 
 interface Props {
   classes: any;
@@ -32,23 +28,18 @@ class Queue extends React.Component<Props, State> {
   }
 
   requestAdd(videoUrl: string): void {
-    debugger;
     this.props.socket.emit(Event.REQUEST_ADD_TO_QUEUE, videoUrl);
   }
 
-  add(title: string): void {
-    debugger;
-    console.log("Adding a video");
+  add(video: Video): void {
     const videos = this.state.videos;
-    const newVideo = { name: title, url: "https://youtube.com" };
-    videos.push(newVideo);
+    videos.push(video);
 
     this.setState({ videos });
   }
 
   componentDidMount() {
-    debugger;
-    this.props.socket.on(Event.ADD_TO_QUEUE, (title: string) => this.add(title));
+    this.props.socket.on(Event.ADD_TO_QUEUE, (video: Video) => this.add(video));
   }
 
   render() {
@@ -72,7 +63,7 @@ class Queue extends React.Component<Props, State> {
         </ListItem>
         {this.state.videos.map((video, i) => (
           <ListItem key={i}>
-            <ListItemText primary={video.name} />
+            <ListItemText primary={video.title} />
           </ListItem>
         ))}
       </List>

--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -78,7 +78,14 @@ class Room extends React.Component<Props, State> {
     });
 
     this.socket.on(Event.SET_VIDEO, (video: Video) => {
-      this.setState({ currVideoId: video.url.replace("https://www.youtube.com/watch?v=", "") });
+      const videoQueue: Video[] = [];
+      let foundVideo = false;
+      for (const v of this.state.videoQueue) {
+        if (foundVideo) videoQueue.push(v);
+        if (v.id == video.id) foundVideo = true;
+      }
+
+      this.setState({ currVideoId: video.url.replace("https://www.youtube.com/watch?v=", ""), videoQueue: videoQueue });
     });
   }
 

--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -38,6 +38,7 @@ class Room extends React.Component<Props, State> {
     this.handleOnPlay = this.handleOnPlay.bind(this);
     this.handleOnStateChange = this.handleOnStateChange.bind(this);
     this.handleOnReady = this.handleOnReady.bind(this);
+    this.handleEnd = this.handleEnd.bind(this);
     this.requestAddToQueue = this.requestAddToQueue.bind(this);
     this.addToQueue = this.addToQueue.bind(this);
   }
@@ -53,10 +54,16 @@ class Room extends React.Component<Props, State> {
   }
 
   handleOnStateChange(event: { target: any; data: number }) {
-    console.log("State has changed");
+    console.log("State has changed with data = " + event.data);
+
+    // If event.data is 5, a new video has just been set so we should play it
+    if (event.data == 5) {
+      event.target.playVideo();
+    }
   }
 
   handleOnReady(event: { target: any }) {
+    console.log("Called handleOnready");
     const player = event.target;
 
     this.socket.on(Event.PLAY_VIDEO, (time: number) => {
@@ -69,6 +76,14 @@ class Room extends React.Component<Props, State> {
     this.socket.on(Event.PAUSE_VIDEO, (time: number) => {
       player.pauseVideo();
     });
+
+    this.socket.on(Event.SET_VIDEO, (video: Video) => {
+      this.setState({ currVideoId: video.url.replace("https://www.youtube.com/watch?v=", "") });
+    });
+  }
+
+  handleEnd(event: { target: any }) {
+    if (this.state.videoQueue.length > 0) this.socket.emit(Event.SET_VIDEO, this.state.videoQueue[0]);
   }
 
   requestAddToQueue(videoUrl: string): void {
@@ -130,6 +145,7 @@ class Room extends React.Component<Props, State> {
             onPlay={this.handleOnPlay}
             onStateChange={this.handleOnStateChange}
             onPause={this.handleOnPause}
+            onEnd={this.handleEnd}
           />
           <Queue onAddVideo={this.requestAddToQueue} videos={this.state.videoQueue} />
         </React.Fragment>

--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -116,7 +116,8 @@ class Room extends React.Component<Props, State> {
           currVideoId: res.data.url.replace("https://www.youtube.com/watch?v=", ""),
           isLoaded: true,
           isValid: true,
-          name: res.data.name
+          name: res.data.name,
+          videoQueue: res.data.videoQueue
         });
       } else {
         this.setState({

--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -6,6 +6,7 @@ import YouTube from "react-youtube";
 import { Event } from "../sockets/event";
 import "../styles/Room.css";
 import loadingIndicator from "../lotties/loading.json";
+import Queue from "./Queue";
 
 interface Props {
   match: any;
@@ -114,6 +115,7 @@ class Room extends React.Component<Props, State> {
             onStateChange={this.handleOnStateChange}
             onPause={this.handleOnPause}
           />
+          <Queue socket={this.socket} />
         </React.Fragment>
       ) : null;
 

--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -10,6 +10,8 @@ import Queue from "./Queue";
 import Video from "../models/video";
 import RoomInfo from "../models/room";
 
+const VIDEO_CUED_EVENT = 5;
+
 interface Props {
   match: any;
 }
@@ -58,7 +60,7 @@ class Room extends React.Component<Props, State> {
     console.log("State has changed with data = " + event.data);
 
     // If event.data is 5, a new video has just been set so we should play it
-    if (event.data == 5) {
+    if (event.data == VIDEO_CUED_EVENT) {
       event.target.playVideo();
     }
   }
@@ -80,7 +82,7 @@ class Room extends React.Component<Props, State> {
 
     this.socket.on(Event.UPDATE_ROOM, (room: RoomInfo) => {
       this.setState({
-        currVideoId: room.url.replace("https://www.youtube.com/watch?v=", ""),
+        currVideoId: room.currVideoId,
         videoQueue: room.videoQueue
       });
     });
@@ -90,8 +92,8 @@ class Room extends React.Component<Props, State> {
     if (this.state.videoQueue.length > 0) this.socket.emit(Event.SET_VIDEO, this.state.videoQueue[0]);
   }
 
-  requestAddToQueue(videoUrl: string): void {
-    this.socket.emit(Event.REQUEST_ADD_TO_QUEUE, videoUrl);
+  requestAddToQueue(videoId: string): void {
+    this.socket.emit(Event.REQUEST_ADD_TO_QUEUE, videoId);
   }
 
   addToQueue(video: Video): void {
@@ -110,7 +112,7 @@ class Room extends React.Component<Props, State> {
       const res = await axios.get("http://localhost:8080/rooms/" + id);
       if (res && res.status === 200) {
         this.setState({
-          currVideoId: res.data.url.replace("https://www.youtube.com/watch?v=", ""),
+          currVideoId: res.data.currVideoId,
           isLoaded: true,
           isValid: true,
           name: res.data.name,

--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -8,6 +8,7 @@ import "../styles/Room.css";
 import loadingIndicator from "../lotties/loading.json";
 import Queue from "./Queue";
 import Video from "../models/video";
+import RoomInfo from "../models/room";
 
 interface Props {
   match: any;
@@ -77,15 +78,11 @@ class Room extends React.Component<Props, State> {
       player.pauseVideo();
     });
 
-    this.socket.on(Event.SET_VIDEO, (video: Video) => {
-      const videoQueue: Video[] = [];
-      let foundVideo = false;
-      for (const v of this.state.videoQueue) {
-        if (foundVideo) videoQueue.push(v);
-        if (v.id == video.id) foundVideo = true;
-      }
-
-      this.setState({ currVideoId: video.url.replace("https://www.youtube.com/watch?v=", ""), videoQueue: videoQueue });
+    this.socket.on(Event.UPDATE_ROOM, (room: RoomInfo) => {
+      this.setState({
+        currVideoId: room.url.replace("https://www.youtube.com/watch?v=", ""),
+        videoQueue: room.videoQueue
+      });
     });
   }
 

--- a/frontend/src/models/room.ts
+++ b/frontend/src/models/room.ts
@@ -1,0 +1,7 @@
+import Video from "./video";
+
+export default interface Room {
+  name: string;
+  url: string;
+  videoQueue: Video[];
+}

--- a/frontend/src/models/room.ts
+++ b/frontend/src/models/room.ts
@@ -2,6 +2,6 @@ import Video from "./video";
 
 export default interface Room {
   name: string;
-  url: string;
+  currVideoId: string;
   videoQueue: Video[];
 }

--- a/frontend/src/models/video.ts
+++ b/frontend/src/models/video.ts
@@ -1,4 +1,5 @@
 export default interface Video {
+  id: string;
   title: string;
   url: string;
 }

--- a/frontend/src/models/video.ts
+++ b/frontend/src/models/video.ts
@@ -1,5 +1,5 @@
 export default interface Video {
   id: string;
   title: string;
-  url: string;
+  currVideoId: string;
 }

--- a/frontend/src/models/video.ts
+++ b/frontend/src/models/video.ts
@@ -1,0 +1,4 @@
+export default interface Video {
+  title: string;
+  url: string;
+}

--- a/frontend/src/sockets/event.ts
+++ b/frontend/src/sockets/event.ts
@@ -1,9 +1,10 @@
 export enum Event {
+  ADD_TO_QUEUE = "add to queue",
   CONNECT = "connect",
   DISCONNECT = "disconnect",
   MESSAGE = "message",
   JOIN_ROOM = "join room",
   PLAY_VIDEO = "play video",
   PAUSE_VIDEO = "pause video",
-  ADD_TO_QUEUE = "add to queue"
+  REQUEST_ADD_TO_QUEUE = "request add to queue"
 }

--- a/frontend/src/sockets/event.ts
+++ b/frontend/src/sockets/event.ts
@@ -7,5 +7,6 @@ export enum Event {
   PLAY_VIDEO = "play video",
   PAUSE_VIDEO = "pause video",
   REQUEST_ADD_TO_QUEUE = "request add to queue",
-  SET_VIDEO = "set video"
+  SET_VIDEO = "set video",
+  UPDATE_ROOM = "update room"
 }

--- a/frontend/src/sockets/event.ts
+++ b/frontend/src/sockets/event.ts
@@ -6,5 +6,6 @@ export enum Event {
   JOIN_ROOM = "join room",
   PLAY_VIDEO = "play video",
   PAUSE_VIDEO = "pause video",
-  REQUEST_ADD_TO_QUEUE = "request add to queue"
+  REQUEST_ADD_TO_QUEUE = "request add to queue",
+  SET_VIDEO = "set video"
 }

--- a/frontend/src/sockets/event.ts
+++ b/frontend/src/sockets/event.ts
@@ -4,5 +4,6 @@ export enum Event {
   MESSAGE = "message",
   JOIN_ROOM = "join room",
   PLAY_VIDEO = "play video",
-  PAUSE_VIDEO = "pause video"
+  PAUSE_VIDEO = "pause video",
+  ADD_TO_QUEUE = "add to queue"
 }


### PR DESCRIPTION
There are still some more additional small features to add to the queue, but the main implementation is done. 

# Changes
* Users can now add to the video queue which will be shared among clients. If a user gives an invalid URL, it will currently just do nothing. 
* Whichever client reaches the end of a video will send out a SET_VIDEO event which will trigger other clients to change their video, start playing, and delete the videos in the queue up to the requested video. 
* When  new users join they get the current video that others are on, and the queue that has been created so far.
* Queue is saved to the database inside the Room information so that we don't have to do conflict resolution between clients regarding which queue is correct (server source of truth) (I know that we discussed that we should request from the clients but I feel pretty strongly that this is pointlessly complex, please comment if you disagree)

# Tickets
This is a preliminary implementation of #50. 

