### PR TITLE
Got video removal working, fixed some incorrect naming.

### DIFF
--- a/backend/src/models/video.ts
+++ b/backend/src/models/video.ts
@@ -1,5 +1,5 @@
 export default interface Video {
   id: string;
   title: string;
-  currVideoId: string;
+  youtubeId: string;
 }

--- a/backend/src/sockets/event.ts
+++ b/backend/src/sockets/event.ts
@@ -1,11 +1,11 @@
 export enum Event {
-  ADD_TO_QUEUE = "add to queue",
   CONNECT = "connect",
   DISCONNECT = "disconnect",
   MESSAGE = "message",
   JOIN_ROOM = "join room",
   PLAY_VIDEO = "play video",
   PAUSE_VIDEO = "pause video",
+  REMOVE_FROM_QUEUE = "remove from queue",
   REQUEST_ADD_TO_QUEUE = "request add to queue",
   SET_VIDEO = "set video",
   UPDATE_ROOM = "update room"

--- a/frontend/src/components/Queue.tsx
+++ b/frontend/src/components/Queue.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import { List, ListItem, ListItemText, TextField, ListItemSecondaryAction, IconButton } from "@material-ui/core";
 import { createStyles, withStyles } from "@material-ui/core/styles";
 import AddIcon from "@material-ui/icons/Add";
+import RemoveIcon from "@material-ui/icons/Remove";
 import Video from "../models/video";
 
 interface Props {
   classes: any;
-  onAddVideo: (videoId: string) => void;
+  onAddVideo: (youtubeId: string) => void;
+  onRemoveVideo: (videoId: string) => void;
   videos: Video[];
 }
 
@@ -38,7 +40,7 @@ class Queue extends React.Component<Props, State> {
           <ListItemSecondaryAction>
             <IconButton
               edge="end"
-              aria-label="comments"
+              aria-label="add"
               onClick={() => {
                 const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=|\?v=)([^#\&\?]*).*/;
                 const match = this.state.newVideoUrl.match(regExp);
@@ -56,6 +58,11 @@ class Queue extends React.Component<Props, State> {
         {this.props.videos.map((video, i) => (
           <ListItem key={i}>
             <ListItemText primary={video.title} />
+            <ListItemSecondaryAction>
+              <IconButton edge="end" aria-label="remove" onClick={() => this.props.onRemoveVideo(video.id)}>
+                <RemoveIcon style={{ color: "white" }} />
+              </IconButton>
+            </ListItemSecondaryAction>
           </ListItem>
         ))}
       </List>

--- a/frontend/src/models/video.ts
+++ b/frontend/src/models/video.ts
@@ -1,5 +1,5 @@
 export default interface Video {
   id: string;
   title: string;
-  currVideoId: string;
+  youtubeId: string;
 }

--- a/frontend/src/sockets/event.ts
+++ b/frontend/src/sockets/event.ts
@@ -1,11 +1,11 @@
 export enum Event {
-  ADD_TO_QUEUE = "add to queue",
   CONNECT = "connect",
   DISCONNECT = "disconnect",
   MESSAGE = "message",
   JOIN_ROOM = "join room",
   PLAY_VIDEO = "play video",
   PAUSE_VIDEO = "pause video",
+  REMOVE_FROM_QUEUE = "remove from queue",
   REQUEST_ADD_TO_QUEUE = "request add to queue",
   SET_VIDEO = "set video",
   UPDATE_ROOM = "update room"


### PR DESCRIPTION
# Changes
Adds a little minus symbol to remove the video from the queue. Should be noted that `youtubeId` in the `Video` interface indicates YouTube's ID in the video URL query string and `id` is just a random uuid to identify the video on the list. These need to be distinct to allow 2 of the same video to be added to the queue. 

# Tickets
Closes #71.
