### PR TITLE
Made room layout use two columns as in the design

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13747,6 +13747,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typeface-roboto": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/typeface-roboto/-/typeface-roboto-0.0.75.tgz",
+      "integrity": "sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg=="
+    },
     "typescript": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",

--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -21,6 +21,7 @@ import { Modal, Backdrop, Fade, withStyles } from "@material-ui/core";
 import Username from "./Username";
 import VideoChat from "./VideoChat";
 import { runInThisContext } from "vm";
+import Box from "@material-ui/core/Box";
 
 enum ModalType {
   NONE = 0,
@@ -331,10 +332,17 @@ class Room extends React.Component<Props, State> {
     return (
       <div className="container">
         <Share roomUrl={window.location.href} />
-        {videoPlayer}
+        <Box display="flex" p={1}>
+          <Box p={1} flexGrow={1}>
+            {videoPlayer}
+          </Box>
+          <Box p={1}>
+            {username && <VideoChat username={username} users={this.state.users} socket={this.socket} />}
+            <Chat username={this.state.username} messages={this.state.messages} sendMessage={this.handleSendMessage} />
+          </Box>
+        </Box>
         {invalidRoomId}
         {showLoadingIndicator}
-        <Chat username={this.state.username} messages={this.state.messages} sendMessage={this.handleSendMessage} />
         <Modal
           disableAutoFocus={true}
           aria-labelledby="transition-modal-title"
@@ -358,7 +366,6 @@ class Room extends React.Component<Props, State> {
             </div>
           </Fade>
         </Modal>
-        {username && <VideoChat username={username} users={this.state.users} socket={this.socket} />}
       </div>
     );
   }


### PR DESCRIPTION
# Changes
This just uses flex boxes to layout the room into two columns like in the design. I think this makes it easier to style the inner components because the parent DOM elements influence the children more than vice versa. I think this will be easier to merge first than my queue styling changes because it is not a `Card` and will occupy the space of its parent `div`


