### PR TITLE
Adjusted chat vertical size. 

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -182,7 +182,7 @@ const materialUiStyles = createStyles({
   },
   parentContainer: {
     position: "relative",
-    height: "100vh",
+    height: "100%",
     overflow: "auto",
     background: "rgba(255, 255, 255, 0.05)"
   },


### PR DESCRIPTION
# Changes
Accidentally used 100vh instead of 100%, so chat component was too tall.
Switched it to take up 100% of the height of the container.

# Tickets
#136 
