### PR TITLE
Video chat username fixes related to joining from Browse rooms

### DIFF
--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -247,6 +247,7 @@ class Room extends React.Component<Props, State> {
       },
       () => {
         this.socket.emit(Event.CREATE_USERNAME, this.state.username);
+        this.socket.emit(Event.GET_ALL_USERNAMES);
       }
     );
   }

--- a/frontend/src/components/VideoChat.tsx
+++ b/frontend/src/components/VideoChat.tsx
@@ -269,10 +269,6 @@ class VideoChat extends React.Component<VideoChatProps, VideoChatState> {
     }
   };
 
-  saveUserName = (username: string) => {
-    this.setState({ name: username });
-  };
-
   render() {
     const { classes, users } = this.props;
     return (

--- a/frontend/src/components/VideoChat.tsx
+++ b/frontend/src/components/VideoChat.tsx
@@ -68,7 +68,7 @@ class VideoChat extends React.Component<VideoChatProps, VideoChatState> {
       peer: null,
       peerVideo: null,
       inVideoChat: false,
-      name: props.username,
+      name: "",
       inviteFromName: "",
       videoChatSet: [],
       videoChatId: null,
@@ -88,6 +88,7 @@ class VideoChat extends React.Component<VideoChatProps, VideoChatState> {
   }
 
   componentDidMount() {
+    const { username } = this.props;
     this.videoRef?.current?.addEventListener("ended", () => console.log("ended"));
     this.peerVideoRef?.current?.addEventListener("ended", () => console.log("ended"));
     this.socket.on("BackOffer", this.frontAnswer);
@@ -105,6 +106,13 @@ class VideoChat extends React.Component<VideoChatProps, VideoChatState> {
     this.socket.on("SEND_VIDEOCHATID", (videoChatIdObj: any) => {
       this.setVideoChatIdAndSetInVideoChat(videoChatIdObj.id);
     });
+    this.setState({ name: username });
+  }
+
+  componentDidUpdate(prevProps: VideoChatProps) {
+    if (this.props.username !== prevProps.username) {
+      this.setState({ name: this.props.username });
+    }
   }
 
   setInVideoChat = () => {
@@ -259,6 +267,10 @@ class VideoChat extends React.Component<VideoChatProps, VideoChatState> {
       peerNode.srcObject = stream;
       this.setState({ peerVideo: stream });
     }
+  };
+
+  saveUserName = (username: string) => {
+    this.setState({ name: username });
   };
 
   render() {


### PR DESCRIPTION
# Changes
Fixes to username related bugs related to joining room from browse rooms.
1) Videochat list doesn't update usernames if a user joined from browse room (Anoynmous Beaver username persisted even after user changed name)
2) Invite modal also used Anoynmous beaver username

# Tickets
#139
