### PR TITLE
Videochat && chat shouldnt stick out to the right

### DIFF
--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -363,7 +363,7 @@ class Room extends React.Component<Props, State> {
             {videoPlayer}
           </Grid>
           <Grid item xs={4}>
-            <Container style={{ background: "#030B1E", width: "40vw" }}>
+            <Container style={{ background: "#030B1E" }}>
               {username && <VideoChat username={username} users={this.state.users} socket={this.socket} />}
               <Chat
                 username={this.state.username}

--- a/frontend/src/components/VideoChat.tsx
+++ b/frontend/src/components/VideoChat.tsx
@@ -299,7 +299,7 @@ class VideoChat extends React.Component<VideoChatProps, VideoChatState> {
         {this.state.inVideoChat && (
           <div className={classes.videoChat}>
             <CardMedia className={classes.cardMedia}>
-              <video style={{ objectFit: "contain", width: "36vw" }} ref={this.peerVideoRef} autoPlay></video>
+              <video style={{ objectFit: "contain", width: "30vw" }} ref={this.peerVideoRef} autoPlay></video>
             </CardMedia>
             <Button onClick={() => this.stopMyVideoChat()} variant="contained" color="secondary">
               Leave


### PR DESCRIPTION
# Changes
Videochat and chat no longer stick out to the right. 
HTML video element also doesnt stick out to the right when using videochat.

# Tickets
Tag the issues that this PR addresses.
